### PR TITLE
chore: Remove now extraneous mock server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ The following are prerequisites for running the demonstration locally:
 ```yaml
 generation:
   # ... other configuration ...
-  mockServer:
-    disabled: false
   tests:
     generateNewTests: true
 ```


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-91/feature-enable-mockserver-generation-for-customers

Mock server is now generated by default with test generation.